### PR TITLE
Link to right page with params

### DIFF
--- a/rails/app/views/items/index.html.erb
+++ b/rails/app/views/items/index.html.erb
@@ -25,7 +25,7 @@
         <p class='user_icon'><%= image_tag item.user.image_url %></p>
       </div>
       <div class='columns column_right'>
-        <h3><span class='truncate'><%= link_to item.title.truncate(80), (extract_url item.url) %></span></h3>
+        <h3><span class='truncate'><%= link_to item.title.truncate(80), item.url %></span></h3>
         <p class='thumbnail'>
           <% if !item.first_image_url.nil?  %>
             <%= image_tag item.first_image_url, width: '100%' %>


### PR DESCRIPTION
## 概要

`extract_url` を使ってたせいで params を必要とするページに正しくリンクが貼られていなかったので対応

ex) http://flags.combinator.jp/?p=423 が http://flags.combinator.jp になってしまっていた
