### PR TITLE
Pinpointing "main"

### DIFF
--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -5,7 +5,7 @@ var user = {}
 var quiche_type = 'main'
 
 chrome.browserAction.onClicked.addListener(function(tab){
-  bake(tab, quiche_type)
+  bake(tab, 'main')
 })
 
 chrome.commands.onCommand.addListener(function(command) {


### PR DESCRIPTION
## 概要

`chrome.browserAction.onClicked` の時に `quiche_type` が `'gouter'` にならないように

`'main'`で決め打ちにする
