### PR TITLE
Enable API to return tags

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -35,6 +35,7 @@ gem 'imgkit'
 gem 'bitly'
 gem 'newrelic_rpm'
 gem 'slack-notify'
+gem 'grape'
 
 group :development do
   gem 'better_errors'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -33,6 +33,10 @@ GEM
     addressable (2.3.6)
     arel (5.0.1.20140414130214)
     awesome_print (1.2.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -46,6 +50,8 @@ GEM
     builder (3.2.2)
     chunky_png (1.3.0)
     coderay (1.1.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -69,6 +75,8 @@ GEM
       debugger-ruby_core_source (~> 1.3.2)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.3.2)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     diffy (3.0.3)
     equalizer (0.0.9)
@@ -81,6 +89,16 @@ GEM
     font-awesome-rails (4.1.0.0)
       railties (>= 3.2, < 5.0)
     fssm (0.2.10)
+    grape (0.7.0)
+      activesupport
+      builder
+      hashie (>= 1.2.0)
+      multi_json (>= 1.3.2)
+      multi_xml (>= 0.5.2)
+      rack (>= 1.3.0)
+      rack-accept
+      rack-mount
+      virtus (>= 1.0.0)
     grit (2.5.0)
       diff-lcs (~> 1.1)
       mime-types (~> 1.15)
@@ -97,6 +115,7 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.6.9)
+    ice_nine (0.11.0)
     imgkit (1.4.1)
     jazz_hands (0.5.2)
       awesome_print (~> 1.2)
@@ -182,6 +201,10 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     rack (1.5.2)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
+    rack-mount (0.8.3)
+      rack (>= 1.0.0)
     rack-test (0.6.2)
       rack (>= 1.0)
     railroady (1.1.1)
@@ -267,6 +290,11 @@ GEM
     uglifier (2.5.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    virtus (1.0.2)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0.3)
+      equalizer (~> 0.0.9)
     yard (0.8.7.4)
 
 PLATFORMS
@@ -281,6 +309,7 @@ DEPENDENCIES
   compass-rails
   fastimage
   font-awesome-rails
+  grape
   imgkit
   jazz_hands
   jbuilder (~> 1.2)

--- a/rails/app/api/api.rb
+++ b/rails/app/api/api.rb
@@ -1,0 +1,11 @@
+class API < Grape::API
+  prefix 'api'
+  version 'v0.1', using: :path
+  format :json
+
+  resource :tag do
+    get do
+      ActsAsTaggableOn::Tag.all
+    end
+  end
+end

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -13,6 +13,8 @@ module LabCache
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.paths.add "app/api", glob: "**/*.rb"
+    config.autoload_paths += Dir["#{Rails.root}/app/api/*"]
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -11,6 +11,8 @@ LabCache::Application.routes.draw do
   get '/auth/:provider/callback' => 'sessions#create'
   get '/signout' => 'sessions#destroy', as: :signout
 
+  mount API => '/'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
## 概要

ひとまず開発用に `/api/v0.1/tag` で tag の一覧が取得できるようにするPRです :tomato: 

![](http://gyazo.l0o0l.co/img/2014-06-06/a3939d8f0f04ab7d1c644fc934e49f6d.png)
