### PR TITLE
Notify comment to slack

### DIFF
--- a/rails/app/models/comment.rb
+++ b/rails/app/models/comment.rb
@@ -11,6 +11,6 @@ class Comment < ActiveRecord::Base
   private
 
   def notify_new_comment
-    tweet "[#{item.title.truncate(50)}]にコメントが付いたよ: 「#{content.truncate(70)}」"
+    slack_notify("[#{item.title}]にコメントが付いたよ: 「#{content}」", '#oven')
   end
 end


### PR DESCRIPTION
twitter との連携を切ったので、コメントも直接 slack に通知する
