### PR TITLE
Solved Issue with configuring and using different accounts in the same ruby process

### DIFF
--- a/ios_client/baker/bake/Info.plist
+++ b/ios_client/baker/bake/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>bake</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>hiroberry.baker.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/ios_client/baker/bake/MainInterface.storyboard
+++ b/ios_client/baker/bake/MainInterface.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="8bI-gs-bmD"/>
+                        <viewControllerLayoutGuide type="bottom" id="d5i-Ba-RvD"/>
+                    </layoutGuides>
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="539" y="97"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios_client/baker/bake/SelectionViewController.m
+++ b/ios_client/baker/bake/SelectionViewController.m
@@ -1,0 +1,14 @@
+//
+//  SelectionViewController.m
+//  baker
+//
+//  Created by hiroberry on 4/1/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <MobileCoreServices/MobileCoreServices.h>
+
+@interface SreViewController ()
+
+@end

--- a/ios_client/baker/bake/ShareViewController.h
+++ b/ios_client/baker/bake/ShareViewController.h
@@ -1,0 +1,15 @@
+//
+//  ShareViewController.h
+//  bake
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <Social/Social.h>
+
+@interface ShareViewController : SLComposeServiceViewController
+
+
+@end

--- a/ios_client/baker/bake/ShareViewController.m
+++ b/ios_client/baker/bake/ShareViewController.m
@@ -1,0 +1,103 @@
+//
+//  ShareViewController.m
+//  bake
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import "ShareViewController.h"
+#import <MobileCoreServices/MobileCoreServices.h>
+
+@interface ShareViewController ()
+
+@property NSString *quiche_type;
+
+@end
+
+@implementation ShareViewController
+
+
+- (void)didSelectPost {
+    // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
+    
+    // Inform the host that we're done, so it un-blocks its UI. Note: Alternatively you could call super's -didSelectPost, which will similarly complete the extension context.
+
+    NSExtensionItem *inputItem = self.extensionContext.inputItems.firstObject;
+    NSItemProvider *urlItemProvider = inputItem.attachments.firstObject;
+    
+    // URLを取り出す
+    if ([urlItemProvider hasItemConformingToTypeIdentifier:(__bridge NSString *)kUTTypeURL]) {
+        [urlItemProvider loadItemForTypeIdentifier:(__bridge NSString *)kUTTypeURL
+                                           options:nil
+                                 completionHandler:^(NSURL *url, NSError *error) {
+                                     // kUTTypeURLの場合itemはNSURLクラスで渡される
+                                     if (!error) {
+                                         NSString *path = [url absoluteString];
+
+                                         NSDictionary *param = @{
+                                             @"url": path,
+                                             @"quiche_type": @"main",
+                                             @"user": @{
+                                                 @"quiche_twitter_id": @"hiroberri"
+                                             }
+                                         };
+
+                                         NSData *jsonData = nil;
+                                         if([NSJSONSerialization isValidJSONObject:param]){
+                                             jsonData = [NSJSONSerialization dataWithJSONObject: param
+                                                                                        options:
+                                                               NSJSONWritingPrettyPrinted error: &error];
+                                         }
+                                         
+                                         NSString *quiche_url = @"http://q.l0o0l.co/item/create";
+                                         // リクエストの種類、ヘッダを設定する
+                                         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL: [NSURL URLWithString: quiche_url]
+                                                                                                cachePolicy: NSURLRequestUseProtocolCachePolicy
+                                                                                            timeoutInterval: 10.0];
+
+                                         [request setHTTPMethod: @"POST"];
+                                         [request setValue: @"application/json"  forHTTPHeaderField: @"Accept"];
+                                         [request setValue: @"application/json"  forHTTPHeaderField: @"Content-Type"];
+
+                                         [request setValue: [NSString stringWithFormat: @"%lu", (unsigned long)[jsonData length]]  forHTTPHeaderField: @"Content-Length"];
+
+                                         [request setHTTPBody: jsonData];
+
+                                         // 共有セッションを取得し、サーバにリクエストを行う
+                                         NSURLSession *session = [NSURLSession sharedSession];
+
+                                         [[session dataTaskWithRequest: request  completionHandler: ^(NSData *data, NSURLResponse *response, NSError *error) {
+                                             
+                                             // レスポンスが成功か失敗かを見てそれぞれ処理を行う		
+                                             if (response && ! error) {
+                                                 NSString *responseString = [[NSString alloc] initWithData: data  encoding: NSUTF8StringEncoding];
+                                                 NSLog(@"Succeeded: %@", responseString);
+                                             }
+                                             else {
+                                                 NSLog(@"Failed: %@", error);
+                                             }
+                                             
+                                         }] resume];
+                                         
+                                         [self.extensionContext completeRequestReturningItems:nil completionHandler:nil];
+                                     }
+                                 }];
+     }
+}
+
+- (NSArray *)configurationItems {
+    SLComposeSheetConfigurationItem *configurationItem = [[SLComposeSheetConfigurationItem alloc] init];
+
+    configurationItem.title = @"Type";
+    configurationItem.value = @"quiche";
+
+    configurationItem.tapHandler = ^(void){
+        UIViewController *viewController = [[UIViewController alloc] init];
+        [self pushConfigurationViewController:viewController];
+    };
+
+    return @[configurationItem];
+}
+
+@end

--- a/ios_client/baker/baker.xcodeproj/project.pbxproj
+++ b/ios_client/baker/baker.xcodeproj/project.pbxproj
@@ -1,0 +1,587 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		89D18B811AC9838900FFF3FF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D18B801AC9838900FFF3FF /* main.m */; };
+		89D18B841AC9838900FFF3FF /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D18B831AC9838900FFF3FF /* AppDelegate.m */; };
+		89D18B871AC9838900FFF3FF /* baker.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 89D18B851AC9838900FFF3FF /* baker.xcdatamodeld */; };
+		89D18B8A1AC9838900FFF3FF /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D18B891AC9838900FFF3FF /* ViewController.m */; };
+		89D18B8D1AC9838900FFF3FF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 89D18B8B1AC9838900FFF3FF /* Main.storyboard */; };
+		89D18B8F1AC9838900FFF3FF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 89D18B8E1AC9838900FFF3FF /* Images.xcassets */; };
+		89D18B921AC9838900FFF3FF /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 89D18B901AC9838900FFF3FF /* LaunchScreen.xib */; };
+		89D18B9E1AC9838900FFF3FF /* bakerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D18B9D1AC9838900FFF3FF /* bakerTests.m */; };
+		89D18BB11AC98DC400FFF3FF /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D18BB01AC98DC400FFF3FF /* ShareViewController.m */; };
+		89D18BB61AC98DC400FFF3FF /* bake.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 89D18BAB1AC98DC400FFF3FF /* bake.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		89D18BBC1ACBA58700FFF3FF /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 89D18BBB1ACBA58700FFF3FF /* MainInterface.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		89D18B981AC9838900FFF3FF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 89D18B731AC9838900FFF3FF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89D18B7A1AC9838900FFF3FF;
+			remoteInfo = baker;
+		};
+		89D18BB41AC98DC400FFF3FF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 89D18B731AC9838900FFF3FF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 89D18BAA1AC98DC400FFF3FF;
+			remoteInfo = bake;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		89D18BBA1AC98DC500FFF3FF /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				89D18BB61AC98DC400FFF3FF /* bake.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		89D18B7B1AC9838900FFF3FF /* baker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = baker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		89D18B7F1AC9838900FFF3FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		89D18B801AC9838900FFF3FF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		89D18B821AC9838900FFF3FF /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		89D18B831AC9838900FFF3FF /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		89D18B861AC9838900FFF3FF /* baker.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = baker.xcdatamodel; sourceTree = "<group>"; };
+		89D18B881AC9838900FFF3FF /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		89D18B891AC9838900FFF3FF /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		89D18B8C1AC9838900FFF3FF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		89D18B8E1AC9838900FFF3FF /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		89D18B911AC9838900FFF3FF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		89D18B971AC9838900FFF3FF /* bakerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = bakerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		89D18B9C1AC9838900FFF3FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		89D18B9D1AC9838900FFF3FF /* bakerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bakerTests.m; sourceTree = "<group>"; };
+		89D18BAB1AC98DC400FFF3FF /* bake.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = bake.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		89D18BAE1AC98DC400FFF3FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		89D18BAF1AC98DC400FFF3FF /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = "<group>"; };
+		89D18BB01AC98DC400FFF3FF /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = "<group>"; };
+		89D18BBB1ACBA58700FFF3FF /* MainInterface.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		89D18B781AC9838900FFF3FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89D18B941AC9838900FFF3FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89D18BA81AC98DC400FFF3FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		89D18B721AC9838900FFF3FF = {
+			isa = PBXGroup;
+			children = (
+				89D18B7D1AC9838900FFF3FF /* baker */,
+				89D18B9A1AC9838900FFF3FF /* bakerTests */,
+				89D18BAC1AC98DC400FFF3FF /* bake */,
+				89D18B7C1AC9838900FFF3FF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		89D18B7C1AC9838900FFF3FF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				89D18B7B1AC9838900FFF3FF /* baker.app */,
+				89D18B971AC9838900FFF3FF /* bakerTests.xctest */,
+				89D18BAB1AC98DC400FFF3FF /* bake.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		89D18B7D1AC9838900FFF3FF /* baker */ = {
+			isa = PBXGroup;
+			children = (
+				89D18B821AC9838900FFF3FF /* AppDelegate.h */,
+				89D18B831AC9838900FFF3FF /* AppDelegate.m */,
+				89D18B881AC9838900FFF3FF /* ViewController.h */,
+				89D18B891AC9838900FFF3FF /* ViewController.m */,
+				89D18B8B1AC9838900FFF3FF /* Main.storyboard */,
+				89D18B8E1AC9838900FFF3FF /* Images.xcassets */,
+				89D18B901AC9838900FFF3FF /* LaunchScreen.xib */,
+				89D18B851AC9838900FFF3FF /* baker.xcdatamodeld */,
+				89D18B7E1AC9838900FFF3FF /* Supporting Files */,
+			);
+			path = baker;
+			sourceTree = "<group>";
+		};
+		89D18B7E1AC9838900FFF3FF /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				89D18B7F1AC9838900FFF3FF /* Info.plist */,
+				89D18B801AC9838900FFF3FF /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		89D18B9A1AC9838900FFF3FF /* bakerTests */ = {
+			isa = PBXGroup;
+			children = (
+				89D18B9D1AC9838900FFF3FF /* bakerTests.m */,
+				89D18B9B1AC9838900FFF3FF /* Supporting Files */,
+			);
+			path = bakerTests;
+			sourceTree = "<group>";
+		};
+		89D18B9B1AC9838900FFF3FF /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				89D18B9C1AC9838900FFF3FF /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		89D18BAC1AC98DC400FFF3FF /* bake */ = {
+			isa = PBXGroup;
+			children = (
+				89D18BAF1AC98DC400FFF3FF /* ShareViewController.h */,
+				89D18BB01AC98DC400FFF3FF /* ShareViewController.m */,
+				89D18BBB1ACBA58700FFF3FF /* MainInterface.storyboard */,
+				89D18BAD1AC98DC400FFF3FF /* Supporting Files */,
+			);
+			path = bake;
+			sourceTree = "<group>";
+		};
+		89D18BAD1AC98DC400FFF3FF /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				89D18BAE1AC98DC400FFF3FF /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		89D18B7A1AC9838900FFF3FF /* baker */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 89D18BA11AC9838900FFF3FF /* Build configuration list for PBXNativeTarget "baker" */;
+			buildPhases = (
+				89D18B771AC9838900FFF3FF /* Sources */,
+				89D18B781AC9838900FFF3FF /* Frameworks */,
+				89D18B791AC9838900FFF3FF /* Resources */,
+				89D18BBA1AC98DC500FFF3FF /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89D18BB51AC98DC400FFF3FF /* PBXTargetDependency */,
+			);
+			name = baker;
+			productName = baker;
+			productReference = 89D18B7B1AC9838900FFF3FF /* baker.app */;
+			productType = "com.apple.product-type.application";
+		};
+		89D18B961AC9838900FFF3FF /* bakerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 89D18BA41AC9838900FFF3FF /* Build configuration list for PBXNativeTarget "bakerTests" */;
+			buildPhases = (
+				89D18B931AC9838900FFF3FF /* Sources */,
+				89D18B941AC9838900FFF3FF /* Frameworks */,
+				89D18B951AC9838900FFF3FF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				89D18B991AC9838900FFF3FF /* PBXTargetDependency */,
+			);
+			name = bakerTests;
+			productName = bakerTests;
+			productReference = 89D18B971AC9838900FFF3FF /* bakerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		89D18BAA1AC98DC400FFF3FF /* bake */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 89D18BB71AC98DC500FFF3FF /* Build configuration list for PBXNativeTarget "bake" */;
+			buildPhases = (
+				89D18BA71AC98DC400FFF3FF /* Sources */,
+				89D18BA81AC98DC400FFF3FF /* Frameworks */,
+				89D18BA91AC98DC400FFF3FF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = bake;
+			productName = bake;
+			productReference = 89D18BAB1AC98DC400FFF3FF /* bake.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		89D18B731AC9838900FFF3FF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = hiroberry;
+				TargetAttributes = {
+					89D18B7A1AC9838900FFF3FF = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+					89D18B961AC9838900FFF3FF = {
+						CreatedOnToolsVersion = 6.1.1;
+						TestTargetID = 89D18B7A1AC9838900FFF3FF;
+					};
+					89D18BAA1AC98DC400FFF3FF = {
+						CreatedOnToolsVersion = 6.1.1;
+						DevelopmentTeam = G9N897JFKG;
+					};
+				};
+			};
+			buildConfigurationList = 89D18B761AC9838900FFF3FF /* Build configuration list for PBXProject "baker" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 89D18B721AC9838900FFF3FF;
+			productRefGroup = 89D18B7C1AC9838900FFF3FF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				89D18B7A1AC9838900FFF3FF /* baker */,
+				89D18B961AC9838900FFF3FF /* bakerTests */,
+				89D18BAA1AC98DC400FFF3FF /* bake */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		89D18B791AC9838900FFF3FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89D18B8D1AC9838900FFF3FF /* Main.storyboard in Resources */,
+				89D18B921AC9838900FFF3FF /* LaunchScreen.xib in Resources */,
+				89D18B8F1AC9838900FFF3FF /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89D18B951AC9838900FFF3FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89D18BA91AC98DC400FFF3FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89D18BBC1ACBA58700FFF3FF /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		89D18B771AC9838900FFF3FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89D18B841AC9838900FFF3FF /* AppDelegate.m in Sources */,
+				89D18B871AC9838900FFF3FF /* baker.xcdatamodeld in Sources */,
+				89D18B8A1AC9838900FFF3FF /* ViewController.m in Sources */,
+				89D18B811AC9838900FFF3FF /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89D18B931AC9838900FFF3FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89D18B9E1AC9838900FFF3FF /* bakerTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		89D18BA71AC98DC400FFF3FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89D18BB11AC98DC400FFF3FF /* ShareViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		89D18B991AC9838900FFF3FF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 89D18B7A1AC9838900FFF3FF /* baker */;
+			targetProxy = 89D18B981AC9838900FFF3FF /* PBXContainerItemProxy */;
+		};
+		89D18BB51AC98DC400FFF3FF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 89D18BAA1AC98DC400FFF3FF /* bake */;
+			targetProxy = 89D18BB41AC98DC400FFF3FF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		89D18B8B1AC9838900FFF3FF /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				89D18B8C1AC9838900FFF3FF /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		89D18B901AC9838900FFF3FF /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				89D18B911AC9838900FFF3FF /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		89D18B9F1AC9838900FFF3FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		89D18BA01AC9838900FFF3FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		89D18BA21AC9838900FFF3FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = baker/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		89D18BA31AC9838900FFF3FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = baker/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		89D18BA51AC9838900FFF3FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = bakerTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/baker.app/baker";
+			};
+			name = Debug;
+		};
+		89D18BA61AC9838900FFF3FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = bakerTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/baker.app/baker";
+			};
+			name = Release;
+		};
+		89D18BB81AC98DC500FFF3FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = bake/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		89D18BB91AC98DC500FFF3FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				INFOPLIST_FILE = bake/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		89D18B761AC9838900FFF3FF /* Build configuration list for PBXProject "baker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89D18B9F1AC9838900FFF3FF /* Debug */,
+				89D18BA01AC9838900FFF3FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		89D18BA11AC9838900FFF3FF /* Build configuration list for PBXNativeTarget "baker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89D18BA21AC9838900FFF3FF /* Debug */,
+				89D18BA31AC9838900FFF3FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		89D18BA41AC9838900FFF3FF /* Build configuration list for PBXNativeTarget "bakerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89D18BA51AC9838900FFF3FF /* Debug */,
+				89D18BA61AC9838900FFF3FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		89D18BB71AC98DC500FFF3FF /* Build configuration list for PBXNativeTarget "bake" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89D18BB81AC98DC500FFF3FF /* Debug */,
+				89D18BB91AC98DC500FFF3FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		89D18B851AC9838900FFF3FF /* baker.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				89D18B861AC9838900FFF3FF /* baker.xcdatamodel */,
+			);
+			currentVersion = 89D18B861AC9838900FFF3FF /* baker.xcdatamodel */;
+			path = baker.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = 89D18B731AC9838900FFF3FF /* Project object */;
+}

--- a/ios_client/baker/baker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios_client/baker/baker.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:baker.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcschemes/bake.xcscheme
+++ b/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcschemes/bake.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   wasCreatedForAppExtension = "YES"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89D18BAA1AC98DC400FFF3FF"
+               BuildableName = "bake.appex"
+               BlueprintName = "bake"
+               ReferencedContainer = "container:baker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89D18B7A1AC9838900FFF3FF"
+               BuildableName = "baker.app"
+               BlueprintName = "baker"
+               ReferencedContainer = "container:baker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89D18BAA1AC98DC400FFF3FF"
+            BuildableName = "bake.appex"
+            BlueprintName = "bake"
+            ReferencedContainer = "container:baker.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89D18B7A1AC9838900FFF3FF"
+            BuildableName = "baker.app"
+            BlueprintName = "baker"
+            ReferencedContainer = "container:baker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89D18B7A1AC9838900FFF3FF"
+            BuildableName = "baker.app"
+            BlueprintName = "baker"
+            ReferencedContainer = "container:baker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcschemes/baker.xcscheme
+++ b/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcschemes/baker.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89D18B7A1AC9838900FFF3FF"
+               BuildableName = "baker.app"
+               BlueprintName = "baker"
+               ReferencedContainer = "container:baker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89D18B961AC9838900FFF3FF"
+               BuildableName = "bakerTests.xctest"
+               BlueprintName = "bakerTests"
+               ReferencedContainer = "container:baker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "89D18B961AC9838900FFF3FF"
+               BuildableName = "bakerTests.xctest"
+               BlueprintName = "bakerTests"
+               ReferencedContainer = "container:baker.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89D18B7A1AC9838900FFF3FF"
+            BuildableName = "baker.app"
+            BlueprintName = "baker"
+            ReferencedContainer = "container:baker.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89D18B7A1AC9838900FFF3FF"
+            BuildableName = "baker.app"
+            BlueprintName = "baker"
+            ReferencedContainer = "container:baker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "89D18B7A1AC9838900FFF3FF"
+            BuildableName = "baker.app"
+            BlueprintName = "baker"
+            ReferencedContainer = "container:baker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios_client/baker/baker.xcodeproj/xcuserdata/hiroberry.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>bake.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+		<key>baker.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>89D18B7A1AC9838900FFF3FF</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>89D18B961AC9838900FFF3FF</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>89D18BAA1AC98DC400FFF3FF</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios_client/baker/baker/AppDelegate.h
+++ b/ios_client/baker/baker/AppDelegate.h
@@ -1,0 +1,25 @@
+//
+//  AppDelegate.h
+//  baker
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <CoreData/CoreData.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@property (readonly, strong, nonatomic) NSManagedObjectContext *managedObjectContext;
+@property (readonly, strong, nonatomic) NSManagedObjectModel *managedObjectModel;
+@property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+
+- (void)saveContext;
+- (NSURL *)applicationDocumentsDirectory;
+
+
+@end
+

--- a/ios_client/baker/baker/AppDelegate.m
+++ b/ios_client/baker/baker/AppDelegate.m
@@ -1,0 +1,127 @@
+//
+//  AppDelegate.m
+//  baker
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    // Saves changes in the application's managed object context before the application terminates.
+    [self saveContext];
+}
+
+#pragma mark - Core Data stack
+
+@synthesize managedObjectContext = _managedObjectContext;
+@synthesize managedObjectModel = _managedObjectModel;
+@synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
+
+- (NSURL *)applicationDocumentsDirectory {
+    // The directory the application uses to store the Core Data store file. This code uses a directory named "hiroberry.baker" in the application's documents directory.
+    return [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+}
+
+- (NSManagedObjectModel *)managedObjectModel {
+    // The managed object model for the application. It is a fatal error for the application not to be able to find and load its model.
+    if (_managedObjectModel != nil) {
+        return _managedObjectModel;
+    }
+    NSURL *modelURL = [[NSBundle mainBundle] URLForResource:@"baker" withExtension:@"momd"];
+    _managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
+    return _managedObjectModel;
+}
+
+- (NSPersistentStoreCoordinator *)persistentStoreCoordinator {
+    // The persistent store coordinator for the application. This implementation creates and return a coordinator, having added the store for the application to it.
+    if (_persistentStoreCoordinator != nil) {
+        return _persistentStoreCoordinator;
+    }
+    
+    // Create the coordinator and store
+    
+    _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
+    NSURL *storeURL = [[self applicationDocumentsDirectory] URLByAppendingPathComponent:@"baker.sqlite"];
+    NSError *error = nil;
+    NSString *failureReason = @"There was an error creating or loading the application's saved data.";
+    if (![_persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType configuration:nil URL:storeURL options:nil error:&error]) {
+        // Report any error we got.
+        NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+        dict[NSLocalizedDescriptionKey] = @"Failed to initialize the application's saved data";
+        dict[NSLocalizedFailureReasonErrorKey] = failureReason;
+        dict[NSUnderlyingErrorKey] = error;
+        error = [NSError errorWithDomain:@"YOUR_ERROR_DOMAIN" code:9999 userInfo:dict];
+        // Replace this with code to handle the error appropriately.
+        // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+        NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+        abort();
+    }
+    
+    return _persistentStoreCoordinator;
+}
+
+
+- (NSManagedObjectContext *)managedObjectContext {
+    // Returns the managed object context for the application (which is already bound to the persistent store coordinator for the application.)
+    if (_managedObjectContext != nil) {
+        return _managedObjectContext;
+    }
+    
+    NSPersistentStoreCoordinator *coordinator = [self persistentStoreCoordinator];
+    if (!coordinator) {
+        return nil;
+    }
+    _managedObjectContext = [[NSManagedObjectContext alloc] init];
+    [_managedObjectContext setPersistentStoreCoordinator:coordinator];
+    return _managedObjectContext;
+}
+
+#pragma mark - Core Data Saving support
+
+- (void)saveContext {
+    NSManagedObjectContext *managedObjectContext = self.managedObjectContext;
+    if (managedObjectContext != nil) {
+        NSError *error = nil;
+        if ([managedObjectContext hasChanges] && ![managedObjectContext save:&error]) {
+            // Replace this implementation with code to handle the error appropriately.
+            // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+            NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+            abort();
+        }
+    }
+}
+
+@end

--- a/ios_client/baker/baker/Base.lproj/LaunchScreen.xib
+++ b/ios_client/baker/baker/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 hiroberry. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="baker" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/ios_client/baker/baker/Base.lproj/Main.storyboard
+++ b/ios_client/baker/baker/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="ufC-wZ-h7g">
+            <objects>
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
+                        <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ios_client/baker/baker/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios_client/baker/baker/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios_client/baker/baker/Info.plist
+++ b/ios_client/baker/baker/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>hiroberry.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ios_client/baker/baker/ViewController.h
+++ b/ios_client/baker/baker/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  baker
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/ios_client/baker/baker/ViewController.m
+++ b/ios_client/baker/baker/ViewController.m
@@ -1,0 +1,27 @@
+//
+//  ViewController.m
+//  baker
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/ios_client/baker/baker/baker.xcdatamodeld/.xccurrentversion
+++ b/ios_client/baker/baker/baker.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>baker.xcdatamodel</string>
+</dict>
+</plist>

--- a/ios_client/baker/baker/baker.xcdatamodeld/baker.xcdatamodel/contents
+++ b/ios_client/baker/baker/baker.xcdatamodeld/baker.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model name="Test1.xcdatamodel" userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+    <elements/>
+</model>

--- a/ios_client/baker/baker/main.m
+++ b/ios_client/baker/baker/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  baker
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/ios_client/baker/bakerTests/Info.plist
+++ b/ios_client/baker/bakerTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>hiroberry.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ios_client/baker/bakerTests/bakerTests.m
+++ b/ios_client/baker/bakerTests/bakerTests.m
@@ -1,0 +1,40 @@
+//
+//  bakerTests.m
+//  bakerTests
+//
+//  Created by hiroberry on 3/30/15.
+//  Copyright (c) 2015 hiroberry. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface bakerTests : XCTestCase
+
+@end
+
+@implementation bakerTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end


### PR DESCRIPTION
fixed <font color="#499"> #2684</font>

The collection_check_boxes generates a default hidden input to prevent a gotcha, like the file_field does.
This PR add a RDoc to this.
I debugged this problem further and found out that while the configuration is actually changed correctly the instance variable @token_hash in the PayPal::SDK::Core::API::REST is never nulled, so every query will still go to the account with configuration config1. 
I wanted to extend the guide on Active Job Basics a bit. The guide is still 'edge' and as I was working myself through it on the official page I had a harder time than usual setting everything up in my app because in my opinion there were some important information missing, especially for newbies that have not much experience.
